### PR TITLE
Use double quotes to split positional parameters

### DIFF
--- a/containerShell.plugin.zsh
+++ b/containerShell.plugin.zsh
@@ -1,10 +1,8 @@
 dockerShell(){
     dockerImage=$1
-    if [ -z $2 ]; then
-        containerCommand="bash"
-    else
+    if [ -n $2 ]; then
         shift 1
-        containerCommand=$(echo $@)
     fi
-    docker run -it --rm  --workdir /app  -v $(pwd):/app $dockerImage $(echo $containerCommand) # this is weird, but the only way it would take a command with a space
+    containerCommand="bin/bash ${@}"
+    docker run -it --rm  --workdir /app  -v $(pwd):/app $dockerImage $containerCommand
 }


### PR DESCRIPTION
"""
  When the expansion occurs within double quotes, and word splitting is
  performed, each parameter expands to a separate word. That is, "$@" is
  equivalent to "$1" "$2"
"""
per: https://tiswww.case.edu/php/chet/bash/bashref.html#Special-Parameters